### PR TITLE
[Feat] #91 - add Implement detail view for posts in MyProfile

### DIFF
--- a/CoPro/CoPro/Presentation/MyProfile/View/RelatedPostsToMeTavleViewCell.swift
+++ b/CoPro/CoPro/Presentation/MyProfile/View/RelatedPostsToMeTavleViewCell.swift
@@ -131,10 +131,11 @@ class RelatedPostsToMeTableViewCell: UITableViewCell {
         }
        
        postImage.snp.makeConstraints {
-//          $0.centerY.equalToSuperview()
+          $0.centerY.equalToSuperview()
           $0.trailing.equalToSuperview()
-          $0.top.bottom.equalToSuperview().inset(3)
+//          $0.top.bottom.equalToSuperview().inset(3)
           $0.width.equalTo(postImage.snp.height)
+          $0.height.equalTo(70)
        }
         
         //First Line

--- a/CoPro/CoPro/Presentation/MyProfile/ViewController/MyContributionsViewController.swift
+++ b/CoPro/CoPro/Presentation/MyProfile/ViewController/MyContributionsViewController.swift
@@ -108,25 +108,13 @@ class MyContributionsViewController: BaseViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
-    
-    
-    
     override func setLayout() {
         view.addSubview(tableView)
         tableView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
-    
-//    private func returnTableCellHeight() -> CGFloat {
-//        switch activeCellType {
-//        case .post, .scrap:
-//            return 100
-//        case .comment:
-//            return 65
-//        }
-//    }
-    
+   
     private func getWriteByMe() {
         if let token = self.keychain.get("accessToken") {
             MyProfileAPI.shared.getWritebyMe(token: token) { result in
@@ -373,10 +361,32 @@ extension MyContributionsViewController: UITableViewDelegate, UITableViewDataSou
             return cell
         }
     }
-    
-//    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-//        return returnTableCellHeight()
-//    }
+   
+   // 셀 클릭시 이벤트 (추후 detailVC에서 분기처리 필요)
+   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+      switch activeCellType {
+      case .post:
+          print("post")
+         let detailVC = DetailBoardViewController()
+         let reverseIndex = (myPostsData?.count ?? 0) - 1 - indexPath.row
+         if let id = self.myPostsData?[reverseIndex].id {
+            detailVC.postId = id
+            self.navigationController?.pushViewController(detailVC, animated: true)
+         }
+          
+      case .scrap:
+         print("scrap")
+         let detailVC = DetailBoardViewController()
+         let reverseIndex = (scrapPostData?.count ?? 0) - 1 - indexPath.row
+         if let id = self.scrapPostData?[reverseIndex].boardID {
+            detailVC.postId = id
+            self.navigationController?.pushViewController(detailVC, animated: true)
+         }
+          
+      case .comment:
+         print("댓글은 이동없음")
+      }
+   }
    
    @objc func backButtonTapped() {
                


### PR DESCRIPTION
## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
- 작성한 게시물 상세보기
- 저장한 게시물 상세보기
- 위 두 상황에서의 Image Layout BugFix

## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->

## Screenshot 📷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "" width ="250">|

## To Reviewers 🙏
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
-  '작성한 게시물' or '저장한 게시물' 을 통해 열리는 상세보기에 대한 분기처리가 DetailBoardViewController 에서 구현되어있지 않으니 게시판 담담자 분께서는 주석확인 이후 작업 부탁드려요.

## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #91 
